### PR TITLE
:art: Use template literals instead of string concatenation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@ export default {
     }),
 
     loaderStyle() {
-      return 'width: ' + this.loadingProgress + '%; '
+      return `width: ${this.loadingProgress}%;`
     }
   },
 


### PR DESCRIPTION
Use template literals instead of string concatenation.  I think it gives more cleanness.